### PR TITLE
cp-56: Add chats and chat messages tables

### DIFF
--- a/backend/src/db/helpers/migration-helper.ts
+++ b/backend/src/db/helpers/migration-helper.ts
@@ -1,0 +1,34 @@
+import { type Knex } from 'knex';
+
+import { CommonColumns } from '#libs/enums/enums.js';
+
+function createTableWithCommonColumns(
+  tableName: string,
+  createColumns: (table: Knex.CreateTableBuilder) => void,
+): (knex: Knex) => Promise<void> {
+  return async function (knex: Knex): Promise<void> {
+    await knex.schema.createTable(tableName, (table) => {
+      table.increments(CommonColumns.ID).primary();
+
+      table
+        .dateTime(CommonColumns.CREATED_AT)
+        .notNullable()
+        .defaultTo(knex.fn.now());
+
+      table
+        .dateTime(CommonColumns.UPDATED_AT)
+        .notNullable()
+        .defaultTo(knex.fn.now());
+
+      createColumns(table);
+    });
+  };
+}
+
+function dropTableIfExists(tableName: string): (knex: Knex) => Promise<void> {
+  return async function (knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(tableName);
+  };
+}
+
+export { createTableWithCommonColumns, dropTableIfExists };

--- a/backend/src/db/migrations/20230822120000_add_chats_table.ts
+++ b/backend/src/db/migrations/20230822120000_add_chats_table.ts
@@ -5,20 +5,16 @@ import {
   dropTableIfExists,
 } from '#db/helpers/migration-helper.js';
 
-const TABLE_NAME = 'users';
+const TABLE_NAME = 'chats';
 
 const ColumnName = {
-  EMAIL: 'email',
-  PASSWORD_HASH: 'password_hash',
-  PASSWORD_SALT: 'password_salt',
+  NAME: 'name',
 };
 
 const up = createTableWithCommonColumns(
   TABLE_NAME,
   (table: Knex.CreateTableBuilder) => {
-    table.string(ColumnName.EMAIL).unique().notNullable();
-    table.text(ColumnName.PASSWORD_HASH).notNullable();
-    table.text(ColumnName.PASSWORD_SALT).notNullable();
+    table.string(ColumnName.NAME).notNullable();
   },
 );
 

--- a/backend/src/db/migrations/20230822123000_add_chat_messages_table.ts
+++ b/backend/src/db/migrations/20230822123000_add_chat_messages_table.ts
@@ -1,0 +1,37 @@
+import { type Knex } from 'knex';
+
+import {
+  createTableWithCommonColumns,
+  dropTableIfExists,
+} from '#db/helpers/migration-helper.js';
+
+const TABLE_NAME = 'chat_messages';
+
+const ColumnName = {
+  NAME: 'name',
+  CHAT_ID: 'chat_id',
+  SENDER_ID: 'sender_id',
+  MESSAGE: 'message',
+};
+
+const up = createTableWithCommonColumns(
+  TABLE_NAME,
+  (table: Knex.CreateTableBuilder) => {
+    table.string(ColumnName.NAME).notNullable();
+    table
+      .integer(ColumnName.CHAT_ID)
+      .notNullable()
+      .references('id')
+      .inTable('chats');
+    table
+      .integer(ColumnName.SENDER_ID)
+      .notNullable()
+      .references('id')
+      .inTable('users');
+    table.text(ColumnName.MESSAGE).notNullable();
+  },
+);
+
+const down = dropTableIfExists(TABLE_NAME);
+
+export { down, up };

--- a/backend/src/libs/enums/common-columns.ts
+++ b/backend/src/libs/enums/common-columns.ts
@@ -1,0 +1,7 @@
+const CommonColumns = {
+  ID: 'id',
+  CREATED_AT: 'created_at',
+  UPDATED_AT: 'updated_at',
+};
+
+export { CommonColumns };

--- a/backend/src/libs/enums/enums.ts
+++ b/backend/src/libs/enums/enums.ts
@@ -1,3 +1,4 @@
+export { CommonColumns } from './common-columns.js';
 export {
   APIPath,
   AppEnvironment,


### PR DESCRIPTION
I have added the tables that chats and chat messages, creating the corresponding migration files. I created a helper to avoid repeating code and updated the default migration to use the helper.

<img width="865" alt="image" src="https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/90299049/9480ea14-7200-4add-849d-e6979169e0ff">

<img width="731" alt="image" src="https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/90299049/956f63c7-ab38-4083-9c3f-eca5ba74b18e">
