### PR TITLE
cp-98: Add hover effect on elements in sign up page

### DIFF
--- a/frontend/src/assets/css/variables.scss
+++ b/frontend/src/assets/css/variables.scss
@@ -4,6 +4,7 @@
   --black: #000000;
   --gray-100: #e2e3e5;
   --gray-200: #6c707a;
+  --gray-250: #484b53;
   --gray-300: #302e36;
   --blue-100: #ebf3ff;
   --blue-200: #acb4d0;

--- a/frontend/src/assets/css/variables.scss
+++ b/frontend/src/assets/css/variables.scss
@@ -4,8 +4,8 @@
   --black: #000000;
   --gray-100: #e2e3e5;
   --gray-200: #6c707a;
-  --gray-250: #484b53;
-  --gray-300: #302e36;
+  --gray-300: #484b53;
+  --gray-400: #302e36;
   --blue-100: #ebf3ff;
   --blue-200: #acb4d0;
   --blue-300: #507ceb;

--- a/frontend/src/libs/components/button/styles.module.scss
+++ b/frontend/src/libs/components/button/styles.module.scss
@@ -6,12 +6,12 @@
   font-weight: 600;
   font-size: 16px;
   white-space: nowrap;
-  background-color: var(--gray-300);
+  background-color: var(--gray-400);
   border: none;
   border-radius: 8px;
   cursor: pointer;
 }
 
 .submit:hover {
-  background-color: var(--gray-250);
+  background-color: var(--gray-300);
 }

--- a/frontend/src/libs/components/button/styles.module.scss
+++ b/frontend/src/libs/components/button/styles.module.scss
@@ -11,3 +11,7 @@
   border-radius: 8px;
   cursor: pointer;
 }
+
+.submit:hover {
+  background-color: var(--gray-250);
+}

--- a/frontend/src/pages/auth/components/sign-up-form/styles.module.scss
+++ b/frontend/src/pages/auth/components/sign-up-form/styles.module.scss
@@ -36,3 +36,7 @@
   font-weight: 600;
   text-decoration: none;
 }
+
+.form-link .text:hover {
+  color: var(--gray-100);
+}


### PR DESCRIPTION
- Hover effect on the submit button
- Added a new shade of gray so the hover on the button looks nicer
- Hover effect on the sign-in link on the signup page

## Images

Submit button hover:

![image](https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/58943798/6b57efcb-23b6-47a2-8192-c9c5d2056c3e)
![image](https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/58943798/d4ada958-269f-4396-95eb-d95fc317fd8d)

Sign in link hover:

![image](https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/58943798/9c2147ea-8b23-4c4d-ae1f-d37e859cc243)
![image](https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/58943798/5e23c318-d38b-4f7c-abd0-9a332e47aa83)
