### PR TITLE
cp-76: Add Splash Screen

### DIFF
--- a/mobile/android/app/src/main/res/values/styles.xml
+++ b/mobile/android/app/src/main/res/values/styles.xml
@@ -4,6 +4,8 @@
     <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
+        <item name="android:windowIsTranslucent">true</item>
+
     </style>
 
 


### PR DESCRIPTION
- added some styles to mobile/android/app/src/main/res/values/styles.xml  so that the first splash screen wasn't visible.


I created the pr again because I reveived this comment: 
![image](https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/108797614/48af2e44-2b23-41b6-bb7f-bb9420704ce1)

The problem was that a white screen with the logo appeared additionally (you can see it in the video attached below)

https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/108797614/0712f51d-e306-4ba7-b53d-d79f7f47416f

