### PR TITLE
cp-61: profile settings sidebar

### DIFF
--- a/frontend/src/libs/components/user-profile/user-profile.tsx
+++ b/frontend/src/libs/components/user-profile/user-profile.tsx
@@ -21,7 +21,7 @@ const UserProfile: React.FC = () => {
     };
   });
 
-  const [activeItem, setActiveItem] = useState<string | null>('notification');
+  const [activeItem, setActiveItem] = useState<string>('notification');
 
   const handleClick = useCallback((key: string) => {
     return () => {

--- a/frontend/src/libs/components/user-profile/user-profile.tsx
+++ b/frontend/src/libs/components/user-profile/user-profile.tsx
@@ -21,7 +21,7 @@ const UserProfile: React.FC = () => {
     };
   });
 
-  const [activeItem, setActiveItem] = useState<string | null>(null);
+  const [activeItem, setActiveItem] = useState<string | null>('notification');
 
   const handleClick = useCallback((key: string) => {
     return () => {


### PR DESCRIPTION
As [stated](https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/issues/61#issuecomment-1715537482) by @oksana-mlynska 
The notifications and reminders option in user profile is not set as a default active option - was fixed by adding 'notification' to the local state as a default value. 

There is also another [question](https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/issues/61#issuecomment-1715588469) from Oksana to @Liza-Veis , waiting for her answer. 

Apart from that - no other issues. 

https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/62558753/672043b8-e6ee-4dfb-8168-d725b590bc24
