### PR TITLE
cp-246: White circles around sidebar options don't have all the same size

### DIFF
--- a/frontend/src/libs/components/icon/icon.tsx
+++ b/frontend/src/libs/components/icon/icon.tsx
@@ -5,12 +5,19 @@ import { iconNameToIcon } from './libs/maps/icon-name-to-icon.map.js';
 type Properties = {
   name: IconName;
   color?: string;
+  width?: string | number;
+  height?: string | number;
 };
 
-const Icon: React.FC<Properties> = ({ name, color = 'currentColor' }) => {
+const Icon: React.FC<Properties> = ({
+  name,
+  color = 'currentColor',
+  width,
+  height,
+}) => {
   const SelectedIcon = iconNameToIcon[name];
 
-  return <SelectedIcon style={{ color }} />;
+  return <SelectedIcon style={{ color, width, height }} />;
 };
 
 export { Icon };

--- a/frontend/src/libs/components/sidebar/sidebar.tsx
+++ b/frontend/src/libs/components/sidebar/sidebar.tsx
@@ -35,7 +35,12 @@ const Sidebar: React.FC<Properties> = ({ routes }) => {
                 <Link to={route.path}>
                   <span className={styles['link']}>
                     <span className="visually-hidden">Go to {route.name}</span>
-                    <Icon name={route.icon} color={IconColor.BLUE} />
+                    <Icon
+                      name={route.icon}
+                      color={IconColor.BLUE}
+                      width="24px"
+                      height="24px"
+                    />
                   </span>
                 </Link>
               </button>

--- a/frontend/src/libs/components/sidebar/styles.module.scss
+++ b/frontend/src/libs/components/sidebar/styles.module.scss
@@ -1,6 +1,4 @@
 .icon {
-  width: 24px;
-  height: 24px;
   filter: invert(43%) sepia(94%) saturate(426%) hue-rotate(185deg)
     brightness(94%) contrast(97%);
 }
@@ -36,6 +34,11 @@
 }
 
 .icon-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 52px;
+  height: 52px;
   padding: 0;
   overflow: hidden;
   background-color: var(--white);
@@ -57,6 +60,8 @@
   width: 52px;
   height: 52px;
   line-height: 0px;
+  border: none;
+  border-radius: 50%;
 }
 
 @media (width < 768px) {


### PR DESCRIPTION
I fixed these issues:

The icons didn't have the same size.
The link was not the same shape as the button container.
The icon container didn't have a fixed width.

![image](https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/107894952/a858d2d2-6f7e-46a6-811c-737e7ab075dc)

![image](https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/107894952/ba593323-eaf2-4909-b36b-68195d33e66f)

