### PR TITLE
cp-304: Card view long titles

### DIFF
--- a/frontend/src/libs/components/card/styles.module.scss
+++ b/frontend/src/libs/components/card/styles.module.scss
@@ -2,6 +2,7 @@
   display: flex;
   align-items: center;
   min-width: 317px;
+  max-width: 317px;
   min-height: 83px;
   margin-top: 15px;
   padding: 3px 67px 3px 3px;
@@ -15,7 +16,8 @@
   cursor: pointer;
 }
 
-.item:hover {
+.item:hover,
+.item:focus {
   background: var(--white);
   box-shadow: 0 4px 20px 0 var(--blue-alpha-30);
 }
@@ -61,10 +63,13 @@
 }
 
 .title {
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  display: -webkit-box;
+  overflow: hidden;
   text-align: left;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  word-wrap: break-word;
+  word-break: break-word;
 }
 
 @media (width < 900px) {


### PR DESCRIPTION
Discussed with @k-mlch how the card should look like with the long text. 

Just for additional information:
1. On the Figma design we have different spaces left for the icons in the My Profile
 
![card_view_6](https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/104642736/53609bff-c971-48c0-8b42-7c354815f231)
![card_view_7](https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/104642736/9de34c31-39a6-4449-b602-bef97a9e65fd)
![card_view_8](https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/104642736/9c1076ee-e4dc-4268-9004-e58413d6e23c)

2. You also can see in the video that imgs/svgs in the card take up too much space when its less then 900px, hence it leaves little space for the icons in the future 

https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/104642736/4e74d298-1c92-47ae-a06e-6cb1c30ab0df

