### PR TITLE
cp-160: Fix back button position on the chat layout

### DIFF
--- a/frontend/src/libs/components/backward-button/styles.module.scss
+++ b/frontend/src/libs/components/backward-button/styles.module.scss
@@ -4,7 +4,7 @@
 
 @media (width < 768px) {
   .backward {
-    position: absolute;
+    position: fixed;
     top: 30px;
     left: 25px;
     z-index: 5;


### PR DESCRIPTION
Done:
- The back arrow doesn't scroll with chat messages after i open the text input field

I can make it relative to chat header and use absolute position, but I think it's better decision to universalize it anywhere in project

https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/92298163/36534a1e-8ceb-4023-a7e6-d75f8f54d3a0

