### PR TITLE
cp-331: Added color to the title of the highlighted card

### DIFF
--- a/frontend/src/libs/components/card/styles.module.scss
+++ b/frontend/src/libs/components/card/styles.module.scss
@@ -43,6 +43,7 @@
 }
 
 .selected {
+  color: var(--blue-300);
   background: var(--white);
   box-shadow: 0 4px 20px 0 var(--blue-alpha-30);
 }


### PR DESCRIPTION
In the issue, it was told to change the color specifically for the active card, but should I add it to hover/focus too?

https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/104642736/86dc4d90-3d65-4258-ab4d-4f8f4277082a

