### PR TITLE
cp-335: Lock theme for the app#335

### DIFF
--- a/mobile/android/app/src/main/res/values/styles.xml
+++ b/mobile/android/app/src/main/res/values/styles.xml
@@ -5,6 +5,7 @@
         <!-- Customize your theme here. -->
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
         <item name="android:windowIsTranslucent">true</item>
+        <item name="android:forceDarkAllowed">false</item>
     </style>
 
 


### PR DESCRIPTION
1. Force light mode in the app when the device is on dark mode to prevent style issues.