### PR TITLE
cp-170: Add Meditation Player Layout

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -8,8 +8,7 @@
       android:icon="@mipmap/ic_launcher"
       android:allowBackup="false"
       android:theme="@style/AppTheme"
-      android:usesCleartextTraffic="true">
-      
+    >
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,9 @@
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:allowBackup="false"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+      android:usesCleartextTraffic="true">
+      
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/mobile/index.js
+++ b/mobile/index.js
@@ -1,6 +1,8 @@
 import { AppRegistry } from 'react-native';
+import TrackPlayer from 'react-native-track-player';
 
 import { name as appName } from './app.json';
 import { App } from './src/libs/components/components';
 
 AppRegistry.registerComponent(appName, () => App);
+TrackPlayer.registerPlaybackService(() => async () => {});

--- a/mobile/src/libs/components/button/styles.ts
+++ b/mobile/src/libs/components/button/styles.ts
@@ -42,7 +42,7 @@ const styles = StyleSheet.create({
     height: 55,
     width: 55,
     shadowColor: AppColor.BLUE_200,
-    elevation: 5,
+    elevation: 20,
   },
   buttonTransparent: {
     backgroundColor: 'transparent',

--- a/mobile/src/libs/components/player/libs/constants.ts
+++ b/mobile/src/libs/components/player/libs/constants.ts
@@ -7,14 +7,14 @@ const MOCKED_PLAYLIST: Track[] = [
     id: '1',
     title: 'Meditation for deep sleep',
     artist: 'Stress relief',
-    url: 'http://traffic.libsyn.com/mindfulorg/winston-breathing-5mins.mp3',
+    url: 'https://traffic.libsyn.com/mindfulorg/winston-breathing-5mins.mp3',
     artwork: '',
   },
   {
     id: '2',
     title: 'Meditation for relaxing',
     artist: 'Relax',
-    url: 'http://traffic.libsyn.com/mindfulorg/SusanKaiserGreenland.mp3',
+    url: 'https://traffic.libsyn.com/mindfulorg/SusanKaiserGreenland.mp3',
     artwork: '',
   },
 ];


### PR DESCRIPTION
- fixed the issue where the player didn't work on production (it turned out that the error was that I used a URL for meditation with HTTP instead of HTTPS, so I temporarily modified the AndroidManifest to allow QA team to see if everything works. Later, if needed, I'll remove it).
- fixed this small [issue ](https://bsa2023.slack.com/archives/C05P563E2MN/p1695286944890439)
- added `TrackPlayer.registerPlaybackService` because without this, I received a lot of warnings