### PR TITLE
cp-257: Fixing responsive height in the side menu

### DIFF
--- a/frontend/src/libs/components/dropdown-menu/styles.module.scss
+++ b/frontend/src/libs/components/dropdown-menu/styles.module.scss
@@ -120,7 +120,7 @@
   left: 0;
 }
 
-@media (width < 768px) {
+@media (width < 768px), (height < 530px) {
   .dropdown {
     display: flex;
   }

--- a/frontend/src/libs/components/navigation-menu-wrapper/styles.module.scss
+++ b/frontend/src/libs/components/navigation-menu-wrapper/styles.module.scss
@@ -11,7 +11,7 @@
   margin-left: 88px;
 }
 
-@media (width < 768px) {
+@media (width < 768px), (height < 530px) {
   .body {
     margin-left: 0;
   }

--- a/frontend/src/libs/components/navigation-menu/styles.module.scss
+++ b/frontend/src/libs/components/navigation-menu/styles.module.scss
@@ -64,8 +64,14 @@
   border-radius: 50%;
 }
 
-@media (width < 768px) {
+@media (width < 768px), (height < 530px) {
   .nav-menu {
     display: none;
+  }
+}
+
+@media (height < 720px) {
+  .nav-menu {
+    gap: 35px;
   }
 }

--- a/frontend/src/libs/components/sidebar/components/sidebar/styles.module.scss
+++ b/frontend/src/libs/components/sidebar/components/sidebar/styles.module.scss
@@ -16,7 +16,7 @@
   }
 }
 
-@media (width < 768px) {
+@media (width < 768px), (height < 530px) {
   .container {
     width: 100%;
   }


### PR DESCRIPTION
Fixed media queries to be responsive to height.


![height responsive](https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/107894952/14bd5f57-b847-4d0f-b8aa-02931f3243cc)
