### PR TITLE
cp-403: fix overlapping of the title and icon in the Card component

### DIFF
--- a/frontend/src/libs/components/card/styles.module.scss
+++ b/frontend/src/libs/components/card/styles.module.scss
@@ -9,7 +9,7 @@
   min-width: 317px;
   min-height: 83px;
   margin-top: 15px;
-  padding: 3px 30px 3px 3px;
+  padding: 3px 60px 3px 3px;
   font-weight: 600;
   font-size: 16px;
   font-family: Montserrat, sans-serif;
@@ -87,7 +87,6 @@
   .item {
     width: 100%;
     min-width: 0;
-    padding: 3px 24px 3px 3px;
   }
 
   .no-image {
@@ -96,10 +95,6 @@
 }
 
 @media (width < 768px) {
-  .item {
-    padding: 3px 30px 3px 3px;
-  }
-
   .no-image {
     padding-left: 20px;
   }


### PR DESCRIPTION
As described in the [issue](https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/issues/403) the Card's title, in case it is too long, overlaps the right icon. 

The right icon is the Button component with a class of `icon-right` with absolute positioning. To fix the issue, increase in card's padding was enough. 
Also made sure there is no overlap on all screen sizes. 

<img width="1071" alt="Screenshot 2023-09-26 at 16 19 43" src="https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/62558753/d055ee1a-8700-4c22-823e-42d74746a8f8">

<img width="1071" alt="Screenshot 2023-09-26 at 16 26 27" src="https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/62558753/411384de-087c-4c74-9d0c-de213d1412e5">


https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/62558753/1a7f4de4-0b94-4c19-80a7-75b31390e695

