### PR TITLE
cp-430: Change Enter meditation name instead of Enter topic name

### DIFF
--- a/frontend/src/pages/meditation/components/add-meditation-modal/add-meditation-modal.tsx
+++ b/frontend/src/pages/meditation/components/add-meditation-modal/add-meditation-modal.tsx
@@ -70,7 +70,7 @@ const AddMeditationModal: React.ForwardRefRenderFunction<
           errors={errors}
           label="Meditation name"
           name="name"
-          placeholder="Enter topic name"
+          placeholder="Enter meditation name"
         />
         <InputFile
           control={control}

--- a/mobile/src/screens/meditation-list/components/add-meditation-modal/add-meditation-modal.tsx
+++ b/mobile/src/screens/meditation-list/components/add-meditation-modal/add-meditation-modal.tsx
@@ -55,7 +55,7 @@ const AddMeditationModal: React.FC<Properties> = ({
           errors={errors}
           label="Topic name"
           name="name"
-          placeholder="Enter topic name"
+          placeholder="Enter meditation name"
           labelColor={AppColor.BLACK}
         />
         <InputFile


### PR DESCRIPTION
Changed placeholder on 'Add meditation' pop-up text 'Enter meditation name' instead of 'Enter topic name'


![image](https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/107894952/56a5b31a-d448-4382-8119-32ff6bd01bc9)
