### PR TITLE
cp-439: bug when viewports height is less than 530px pages are overlapping

### DIFF
--- a/frontend/src/libs/components/backward-button/styles.module.scss
+++ b/frontend/src/libs/components/backward-button/styles.module.scss
@@ -2,7 +2,7 @@
   display: none;
 }
 
-@media (width < 768px) {
+@media (width < 768px), (height < 530px) {
   .backward {
     position: fixed;
     top: 30px;

--- a/frontend/src/libs/components/card/styles.module.scss
+++ b/frontend/src/libs/components/card/styles.module.scss
@@ -83,7 +83,7 @@
   word-break: break-word;
 }
 
-@media (width < 900px) {
+@media (width < 900px), (height < 530px) {
   .item {
     width: 100%;
     min-width: 0;

--- a/frontend/src/libs/components/sidebar/components/sidebar/styles.module.scss
+++ b/frontend/src/libs/components/sidebar/components/sidebar/styles.module.scss
@@ -19,6 +19,7 @@
 @media (width < 768px), (height < 530px) {
   .container {
     width: 100%;
+    overflow-y: scroll;
   }
 
   .hide {

--- a/frontend/src/pages/chat/components/chat-header/styles.module.scss
+++ b/frontend/src/pages/chat/components/chat-header/styles.module.scss
@@ -26,7 +26,7 @@
   line-height: 1.5;
 }
 
-@media (width < 768px) {
+@media (width < 768px), (height < 530px) {
   .header-content {
     padding: 25px 95px;
   }

--- a/frontend/src/pages/chat/styles.module.scss
+++ b/frontend/src/pages/chat/styles.module.scss
@@ -15,7 +15,7 @@
   }
 }
 
-@media (width < 768px) {
+@media (width < 768px), (height < 530px) {
   .container {
     width: 100%;
     padding-left: 0;

--- a/frontend/src/pages/journal/styles.module.scss
+++ b/frontend/src/pages/journal/styles.module.scss
@@ -22,7 +22,7 @@
   }
 }
 
-@media (width < 768px) {
+@media (width < 768px), (height < 530px) {
   .container {
     width: 100%;
     padding: 70px 0 0;

--- a/frontend/src/pages/meditation/components/meditation-list/styles.module.scss
+++ b/frontend/src/pages/meditation/components/meditation-list/styles.module.scss
@@ -18,7 +18,7 @@
   }
 }
 
-@media (width < 768px) {
+@media (width < 768px), (height < 530px) {
   .container {
     width: 100%;
     padding: 70px 0 0;

--- a/frontend/src/pages/user-profile/styles.module.scss
+++ b/frontend/src/pages/user-profile/styles.module.scss
@@ -11,7 +11,7 @@
   }
 }
 
-@media (width < 768px) {
+@media (width < 768px), (height < 530px) {
   .container {
     width: 100%;
     padding: 70px 25px 0;


### PR DESCRIPTION
fixed height responsiveness in page layouts. 


![layout height responsive](https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/107894952/5720e0ff-e576-4821-9150-07d21a0c89a3)
