### PR TITLE
cp-497: Fix note page fields after restarting

### DIFF
--- a/frontend/src/pages/journal/journal.tsx
+++ b/frontend/src/pages/journal/journal.tsx
@@ -22,15 +22,19 @@ const Journal: React.FC = () => {
   const { isSidebarShown, setIsSidebarShow } = useSidebarState();
   const { filter, setFilter } = useSearch();
 
-  const { journalEntriesDataStatus } = useAppSelector(({ journal }) => {
-    return {
-      journalEntriesDataStatus: journal.journalEntriesDataStatus,
-    };
-  });
+  const { selectedJournalEntry, journalEntriesDataStatus } = useAppSelector(
+    ({ journal }) => {
+      return {
+        selectedJournalEntry: journal.selectedJournalEntry,
+        journalEntriesDataStatus: journal.journalEntriesDataStatus,
+      };
+    },
+  );
 
   const isLoading =
     journalEntriesDataStatus === DataStatus.IDLE ||
-    journalEntriesDataStatus === DataStatus.PENDING;
+    journalEntriesDataStatus === DataStatus.PENDING ||
+    Boolean(id) !== Boolean(selectedJournalEntry);
 
   const handleBackButtonPress = useCallback(() => {
     dispatch(journalActions.setSelectedJournalEntry(null));


### PR DESCRIPTION
Done: 
- the note page remains the same after restarting the page

https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/92298163/9eeea92c-56a1-4a55-84ad-b94cf36a66a3

