### PR TITLE
cp-492: Fix User Can't Play The Updated Meditation

### DIFF
--- a/mobile/src/libs/packages/player/player.package.ts
+++ b/mobile/src/libs/packages/player/player.package.ts
@@ -65,6 +65,10 @@ class Player {
   public seek = async (value: number): Promise<void> => {
     await TrackPlayer.seekTo(value);
   };
+
+  public setFirstTrack = async (trackId: number): Promise<void> => {
+    await TrackPlayer.skip(trackId);
+  };
 }
 
 export { Player };

--- a/mobile/src/screens/meditation/meditation.tsx
+++ b/mobile/src/screens/meditation/meditation.tsx
@@ -31,7 +31,7 @@ const Meditation: React.FC = () => {
       const currentTrackIndex = meditationEntries.findIndex((item) => {
         return item.id === selectedMeditationEntry.id;
       });
-      void player.setFirstTrack(Number(currentTrackIndex));
+      void player.setFirstTrack(currentTrackIndex);
     }
   }, [selectedMeditationEntry, meditationEntries]);
 

--- a/mobile/src/screens/meditation/meditation.tsx
+++ b/mobile/src/screens/meditation/meditation.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import imagePlaceholder from '#assets/img/card-image-placeholder.png';
 import meditationBackground from '#assets/img/meditation-background.png';
 import { Image, Player, Text, View } from '#libs/components/components';
-import { useAppRoute, useAppSelector } from '#libs/hooks/hooks';
+import { useAppRoute, useAppSelector, useEffect } from '#libs/hooks/hooks';
+import { player } from '#libs/packages/player/player';
 
 import { TITLE_LINE_COUNT } from './libs/constants/constants';
 import { styles } from './styles';
@@ -13,14 +14,26 @@ type RouteParameters = {
 };
 
 const Meditation: React.FC = () => {
-  const { selectedMeditationEntry } = useAppSelector(({ meditation }) => {
-    return {
-      selectedMeditationEntry: meditation.selectedMeditationEntry,
-    };
-  });
+  const { selectedMeditationEntry, meditationEntries } = useAppSelector(
+    ({ meditation }) => {
+      return {
+        selectedMeditationEntry: meditation.selectedMeditationEntry,
+        meditationEntries: meditation.meditationEntries,
+      };
+    },
+  );
 
   const route = useAppRoute();
   const { duration }: RouteParameters = route.params as RouteParameters;
+
+  useEffect(() => {
+    if (selectedMeditationEntry) {
+      const currentTrackIndex = meditationEntries.findIndex((item) => {
+        return item.id === selectedMeditationEntry.id;
+      });
+      void player.setFirstTrack(Number(currentTrackIndex));
+    }
+  }, [selectedMeditationEntry, meditationEntries]);
 
   return (
     <View style={styles.wrapper}>


### PR DESCRIPTION
In the ticket @k-mlch described the issue with meditations, which was because mocked data was still being used at that time. But now I have encountered a different problem - when I play a track, a completely different one starts playing (only the first one)

The issue was that by default, `react-native-track-player` sets the first track added to the playlist as the initial track. So, I had to manually set the inital track to make everything work correctly