### PR TITLE
cp-517: FIx Text Placeholder

### DIFF
--- a/mobile/src/libs/components/rich-text-editor/rich-text-editor.tsx
+++ b/mobile/src/libs/components/rich-text-editor/rich-text-editor.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { RichEditor } from 'react-native-pell-rich-editor';
 
+import { useState } from '#libs/hooks/hooks';
+
+import { Text } from '../components';
 import { styles } from './styles';
 
 type Properties = {
@@ -14,14 +17,26 @@ const RichTextEditor: React.FC<Properties> = ({
   initialContent,
   placeholder,
 }) => {
+  const [isPlaceholderVisible, setIsPlaceholderVisible] = useState(true);
+
+  const handleChange = (content: string): void => {
+    onChange(content);
+    setIsPlaceholderVisible(content === '<p><br></p>');
+  };
+
   return (
-    <RichEditor
-      onChange={onChange}
-      initialContentHTML={initialContent}
-      editorStyle={styles.editor}
-      placeholder={placeholder}
-      androidLayerType="software"
-    />
+    <>
+      {isPlaceholderVisible && (
+        <Text style={styles.placeholder}>{placeholder}</Text>
+      )}
+
+      <RichEditor
+        onChange={handleChange}
+        initialContentHTML={initialContent}
+        editorStyle={styles.editor}
+        androidLayerType="software"
+      />
+    </>
   );
 };
 

--- a/mobile/src/libs/components/rich-text-editor/styles.ts
+++ b/mobile/src/libs/components/rich-text-editor/styles.ts
@@ -1,8 +1,16 @@
 import { StyleSheet } from 'react-native';
 
+import { AppColor } from '#libs/enums/enums';
+
 const styles = StyleSheet.create({
   editor: {
     backgroundColor: 'transparent',
+  },
+  placeholder: {
+    color: AppColor.GRAY_400,
+    position: 'absolute',
+    top: 85,
+    left: 25,
   },
 });
 


### PR DESCRIPTION
The problem was that if the 'initialContentHTML' property was set, the placeholder was ignored. And in our case, 'initialContentHTML' was always set to "`<p><br></p>`" initially. So, I had to add a state to track if the placeholder can be displayed on the page. The only thing I'm not very confident about is the 'position: 'absolute'' property because I'm afraid it might look bad on other devices. But I can't figure out how to get rid of 'position: 'absolute'(

![image](https://github.com/BinaryStudioAcademy/bsa-2023-calmpal/assets/108797614/ad3472ec-2297-4ecd-9650-1d2e0e5284ed)
